### PR TITLE
Fix `outDir` path on `vite.config`

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [react()],
   root: "src",
   build: {
-    outDir: "dist", // Specify the output directory
+    outDir: "../dist", // Specify the output directory
     commonjsOptions: {
       transformMixedEsModules: true,
       // include: [/linked-dep/, /node_modules/],


### PR DESCRIPTION
- Previously created `dist` directory inside `src`
- Caused problem deploying